### PR TITLE
Circumvented Deprecated API Call / Invalid Arg Error

### DIFF
--- a/correction.lua
+++ b/correction.lua
@@ -477,5 +477,3 @@ function cosFix:CorrectShoulderOffset(enteringVehicleGuid)
   return returnValue
 
 end
-
-

--- a/correction.lua
+++ b/correction.lua
@@ -11,7 +11,7 @@ local C_MountJournal_GetMountInfoByID = _G.C_MountJournal.GetMountInfoByID
 local C_MountJournal_GetMountIDs = _G.C_MountJournal.GetMountIDs
 local GetShapeshiftFormID = _G.GetShapeshiftFormID
 local IsMounted = _G.IsMounted
-local UnitBuff = _G.UnitBuff
+local UnitBuff = C_TooltipInfo.GetUnitBuff
 local UnitClass = _G.UnitClass
 local UnitInVehicle = _G.UnitInVehicle
 local UnitGUID = _G.UnitGUID
@@ -477,4 +477,5 @@ function cosFix:CorrectShoulderOffset(enteringVehicleGuid)
   return returnValue
 
 end
+
 

--- a/events.lua
+++ b/events.lua
@@ -8,7 +8,24 @@ local tremove = _G.tremove
 local tinsert = _G.tinsert
 local unpack = _G.unpack
 
-local C_MountJournal_GetMountInfoByID = _G.C_MountJournal.GetMountInfoByID
+local function SafeMountInfoByID(mountID)
+    if not mountID or type(mountID) ~= "number" then
+        return nil, nil, nil, nil, nil
+    end
+
+    local f
+    if C_MountJournal then
+        f = C_MountJournal.GetMountInfoByID or C_MountJournal.GetMountInfo
+    end
+
+    if f then
+        return f(mountID)
+    end
+
+    return nil, nil, nil, nil, nil
+end
+
+local C_MountJournal_GetMountInfoByID = SafeMountInfoByID
 local GetShapeshiftFormID = _G.GetShapeshiftFormID
 local InCombatLockdown = _G.InCombatLockdown
 local IsIndoors = _G.IsIndoors
@@ -906,4 +923,5 @@ function cosFix:RegisterEvents()
   self:RegisterEvent("PLAYER_ENTERING_WORLD", "ShoulderOffsetEventHandler")
 
 end
+
 


### PR DESCRIPTION
Replaced UnitBuff with C_TooltipInfo.GetUnitBuff, since UnitBuff has been deprecated.
Resolved error:
`Message: ...nterface/AddOns/CameraOverShoulderFix/correction.lua:297: attempt to call upvalue 'UnitBuff' (a nil value)`

Patched an issue with the mount journal API that repeatedly threw:

`Message: bad argument #1 to '?' (Usage: local name, spellID, icon, isActive, isUsable, sourceType, isFavorite, isFactionSpecific, faction, shouldHideOnChar, isCollected, mountID, isSteadyFlight = C_MountJourn...)`
This error prevented the camera from resetting correctly after dismounting.

Added API checks and error handling as a temporary workaround until a proper fix is in place.

These changes should stop the addon from throwing runtime errors in current builds while maintaining functionality.
